### PR TITLE
Split entrypoint cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
-ARG CHE_RUNTIME_VERSION=next
+ARG CHE_RUNTIME_VERSION=7.1.0
 ARG PYTHON_VERSION=36
 
 FROM eclipse/che-theia-endpoint-runtime:${CHE_RUNTIME_VERSION} as endpoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,13 @@ COPY --from=endpoint /home/theia /home/theia
 COPY --from=endpoint /projects /projects
 COPY --from=endpoint /etc/passwd  /etc/passwd
 COPY --from=endpoint /etc/group   /etc/group
-COPY --from=endpoint /entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
+COPY cmd.sh /cmd.sh
 
 RUN chmod -R 777 ${HOME} /etc/passwd /etc/group
 
 USER node
 
-ENTRYPOINT ["bash", "/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash", "/cmd.sh"]
 

--- a/cmd.sh
+++ b/cmd.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+cd /home/theia
+
+[ -f "/before-start.sh" ] && . "/before-start.sh"
+
+# run theia endpoint
+export HOME=/home/theia && node /home/theia/lib/node/plugin-remote.js &
+
+PID=$!
+
+# See: http://veithen.github.io/2014/11/16/sigterm-propagation.html
+wait ${PID}
+wait ${PID}
+EXIT_STATUS=$?
+
+# wait forever
+while true
+do
+  tail -f /dev/null & wait ${!}
+done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+
+if ! grep -Fq "${USER_ID}" /etc/passwd; then
+    # current user is an arbitrary
+    # user (its uid is not in the
+    # container /etc/passwd). Let's fix that
+    cat /home/theia/passwd.template | \
+    sed "s/\${USER_ID}/${USER_ID}/g" | \
+    sed "s/\${GROUP_ID}/${GROUP_ID}/g" | \
+    sed "s/\${HOME}/\/projects/g" > /etc/passwd
+
+    cat /home/theia/group.template | \
+    sed "s/\${USER_ID}/${USER_ID}/g" | \
+    sed "s/\${GROUP_ID}/${GROUP_ID}/g" | \
+    sed "s/\${HOME}/\/projects/g" > /etc/group
+fi
+
+# Grant access to projects volume in case of non root user with sudo rights
+if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /dev/null 2>&1; then
+    sudo chown ${USER_ID}:${GROUP_ID} /projects
+fi
+
+# SITTERM / SIGINT
+responsible_shutdown() {
+  echo ""
+  echo "Received SIGTERM"
+  kill -SIGINT ${PID}
+  wait ${PID}
+  exit;
+}
+
+set -e
+
+# setup handlers
+# on callback, kill the last background process, which is `tail -f /dev/null` and execute the specified handler
+trap 'responsible_shutdown' SIGHUP SIGTERM SIGINT
+
+exec "$@"
+
+


### PR DESCRIPTION
splitting entrypoint and cmd to be able to run just override passd changes and not theia start when using the container without serving a vscode ext.